### PR TITLE
Fix coroutine detection on partials

### DIFF
--- a/aiocron/__init__.py
+++ b/aiocron/__init__.py
@@ -14,7 +14,11 @@ async def null_callback(*args):
 
 def wrap_func(func):
     """wrap in a coroutine"""
-    if not asyncio.iscoroutinefunction(func):
+    if isinstance(func, functools.partial):
+        _func = func.func
+    else:
+        _func = func
+    if not asyncio.iscoroutinefunction(_func):
         @functools.wraps(func)
         async def wrapper(*args, **kwargs):
             return func(*args, **kwargs)


### PR DESCRIPTION
This code is not working (Python 3.7):
```
async def do_dump(job: str):
    ...

crontab(job.cron, func=partial(do_dump, job), start=True)
```
It leads to a "do_dump() is never awaited" error => due to asyncio.iscoroutinefunction(), it does not consider the partial function as a coroutine.
Or maybe is there another way to do ? 

I have tested the fix on Python 3.7 only.

This PR is a proposal to support coroutine as functools.partial()