### PR TITLE
switch to cronsim for cron parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 keywords = ["crontab", "cron", "asyncio"]
 dependencies = [
     "cronsim>=2.6",
+    "python-dateutil>=2.9.0",
     "tox>=4.21.1",
     "tox-uv>=1.13.0",
     "tzlocal>=5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 keywords = ["crontab", "cron", "asyncio"]
 dependencies = [
-    "croniter>=3.0.3",
+    "cronsim>=2.6",
     "tox>=4.21.1",
     "tox-uv>=1.13.0",
     "tzlocal>=5.2",

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -14,7 +14,7 @@ class CustomError(Exception):
 def test_str():
     loop = asyncio.new_event_loop()
 
-    @crontab("* * * * * *", loop=loop)
+    @crontab("* * * * *", loop=loop)
     def t():
         pass
 
@@ -26,7 +26,7 @@ def test_cron():
 
     future = asyncio.Future(loop=loop)
 
-    @crontab("* * * * * *", start=False, loop=loop)
+    @crontab("* * * * *", start=False, loop=loop)
     def t():
         future.set_result(1)
 
@@ -41,7 +41,7 @@ def test_raise():
 
     future = asyncio.Future(loop=loop)
 
-    @crontab("* * * * * *", start=False, loop=loop)
+    @crontab("* * * * *", start=False, loop=loop)
     def t():
         loop.call_later(1, future.set_result, 1)
         raise ValueError()
@@ -58,7 +58,7 @@ def test_next():
     def t():
         return 1
 
-    t = crontab("* * * * * *", func=t, loop=loop)
+    t = crontab("* * * * *", func=t, loop=loop)
 
     future = asyncio.ensure_future(t.next(), loop=loop)
 
@@ -69,7 +69,7 @@ def test_next():
 def test_null_callback():
     loop = asyncio.new_event_loop()
 
-    t = crontab("* * * * * *", loop=loop)
+    t = crontab("* * * * *", loop=loop)
 
     assert t.handle is None  # not started
 
@@ -82,7 +82,7 @@ def test_null_callback():
 def test_next_raise():
     loop = asyncio.new_event_loop()
 
-    @crontab("* * * * * *", loop=loop)
+    @crontab("* * * * *", loop=loop)
     def t():
         raise CustomError()
 
@@ -95,7 +95,7 @@ def test_next_raise():
 def test_coro_next():
     loop = asyncio.new_event_loop()
 
-    @crontab("* * * * * *", loop=loop)
+    @crontab("* * * * *", loop=loop)
     async def t():
         return 1
 
@@ -108,7 +108,7 @@ def test_coro_next():
 def test_coro_next_raise():
     loop = asyncio.new_event_loop()
 
-    @crontab("* * * * * *", loop=loop)
+    @crontab("* * * * *", loop=loop)
     async def t():
         raise CustomError()
 


### PR DESCRIPTION
Avoid DST related bugs, such as those reported in #7.

[CronSim](https://github.com/cuu508/cronsim/tree/main) is an alternative implementation of cron parsing in python and was (according to its documentation) explicitly designed to follow Debian's cron implementation, including the DST behavior.

My tests look quite promising and the issues I had noticed vanished using no `tz` parameter. Passing a zoneinfo timezone to the crontab decorator worked, as well as `dateutil.tz.tzlocal()`.

Unfortunately, this is a breaking change since I had to remove `croniter_kwargs`, of course.